### PR TITLE
feat(duplicate): dHash類似スキャン機能を追加

### DIFF
--- a/drizzle/application/0002_cool_grandmaster.sql
+++ b/drizzle/application/0002_cool_grandmaster.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `similarity_scan_queue` (
+	`id` text PRIMARY KEY NOT NULL,
+	`content_hash_id` text NOT NULL,
+	`created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	FOREIGN KEY (`content_hash_id`) REFERENCES `content_hashs`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/drizzle/application/meta/0002_snapshot.json
+++ b/drizzle/application/meta/0002_snapshot.json
@@ -1,0 +1,750 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "5689539e-1135-4591-bcbb-50550e1629df",
+	"prevId": "25ed764b-09ea-4c5a-8228-0e644b78b7b4",
+	"tables": {
+		"authors": {
+			"name": "authors",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"urls": {
+					"name": "urls",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"contents": {
+			"name": "contents",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"path": {
+					"name": "path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"content_hashs": {
+			"name": "content_hashs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content_id": {
+					"name": "content_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"content_hashs_content_id_contents_id_fk": {
+					"name": "content_hashs_content_id_contents_id_fk",
+					"tableFrom": "content_hashs",
+					"tableTo": "contents",
+					"columnsFrom": ["content_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"duplicate_groups": {
+			"name": "duplicate_groups",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"hash_type": {
+					"name": "hash_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"duplicate_group_items": {
+			"name": "duplicate_group_items",
+			"columns": {
+				"group_id": {
+					"name": "group_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content_id": {
+					"name": "content_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"similarity": {
+					"name": "similarity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"duplicate_group_items_group_id_duplicate_groups_id_fk": {
+					"name": "duplicate_group_items_group_id_duplicate_groups_id_fk",
+					"tableFrom": "duplicate_group_items",
+					"tableTo": "duplicate_groups",
+					"columnsFrom": ["group_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"duplicate_group_items_content_id_contents_id_fk": {
+					"name": "duplicate_group_items_content_id_contents_id_fk",
+					"tableFrom": "duplicate_group_items",
+					"tableTo": "contents",
+					"columnsFrom": ["content_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"duplicate_group_items_group_id_content_id_pk": {
+					"columns": ["group_id", "content_id"],
+					"name": "duplicate_group_items_group_id_content_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"illusts": {
+			"name": "illusts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"illusts_authors": {
+			"name": "illusts_authors",
+			"columns": {
+				"illust_id": {
+					"name": "illust_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"illusts_authors_illust_id_illusts_id_fk": {
+					"name": "illusts_authors_illust_id_illusts_id_fk",
+					"tableFrom": "illusts_authors",
+					"tableTo": "illusts",
+					"columnsFrom": ["illust_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"illusts_authors_author_id_authors_id_fk": {
+					"name": "illusts_authors_author_id_authors_id_fk",
+					"tableFrom": "illusts_authors",
+					"tableTo": "authors",
+					"columnsFrom": ["author_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"illusts_authors_illust_id_author_id_pk": {
+					"columns": ["illust_id", "author_id"],
+					"name": "illusts_authors_illust_id_author_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"illusts_contents": {
+			"name": "illusts_contents",
+			"columns": {
+				"illust_id": {
+					"name": "illust_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content_id": {
+					"name": "content_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"order": {
+					"name": "order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"illusts_contents_illust_id_illusts_id_fk": {
+					"name": "illusts_contents_illust_id_illusts_id_fk",
+					"tableFrom": "illusts_contents",
+					"tableTo": "illusts",
+					"columnsFrom": ["illust_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"illusts_contents_content_id_contents_id_fk": {
+					"name": "illusts_contents_content_id_contents_id_fk",
+					"tableFrom": "illusts_contents",
+					"tableTo": "contents",
+					"columnsFrom": ["content_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"illusts_contents_illust_id_content_id_pk": {
+					"columns": ["illust_id", "content_id"],
+					"name": "illusts_contents_illust_id_content_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"illusts_tags": {
+			"name": "illusts_tags",
+			"columns": {
+				"illust_id": {
+					"name": "illust_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tag_id": {
+					"name": "tag_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"illusts_tags_illust_id_illusts_id_fk": {
+					"name": "illusts_tags_illust_id_illusts_id_fk",
+					"tableFrom": "illusts_tags",
+					"tableTo": "illusts",
+					"columnsFrom": ["illust_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"illusts_tags_tag_id_tags_id_fk": {
+					"name": "illusts_tags_tag_id_tags_id_fk",
+					"tableFrom": "illusts_tags",
+					"tableTo": "tags",
+					"columnsFrom": ["tag_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"illusts_tags_illust_id_tag_id_pk": {
+					"columns": ["illust_id", "tag_id"],
+					"name": "illusts_tags_illust_id_tag_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"similarity_scan_queue": {
+			"name": "similarity_scan_queue",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content_hash_id": {
+					"name": "content_hash_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"similarity_scan_queue_content_hash_id_content_hashs_id_fk": {
+					"name": "similarity_scan_queue_content_hash_id_content_hashs_id_fk",
+					"tableFrom": "similarity_scan_queue",
+					"tableTo": "content_hashs",
+					"columnsFrom": ["content_hash_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"tags": {
+			"name": "tags",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"tags_name_unique": {
+					"name": "tags_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"tag_cooccurrences": {
+			"name": "tag_cooccurrences",
+			"columns": {
+				"tag1_id": {
+					"name": "tag1_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tag2_id": {
+					"name": "tag2_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"count": {
+					"name": "count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"tag_cooccurrences_tag1_id_tags_id_fk": {
+					"name": "tag_cooccurrences_tag1_id_tags_id_fk",
+					"tableFrom": "tag_cooccurrences",
+					"tableTo": "tags",
+					"columnsFrom": ["tag1_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tag_cooccurrences_tag2_id_tags_id_fk": {
+					"name": "tag_cooccurrences_tag2_id_tags_id_fk",
+					"tableFrom": "tag_cooccurrences",
+					"tableTo": "tags",
+					"columnsFrom": ["tag2_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"tag_cooccurrences_tag1_id_tag2_id_pk": {
+					"columns": ["tag1_id", "tag2_id"],
+					"name": "tag_cooccurrences_tag1_id_tag2_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"videos": {
+			"name": "videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"videos_authors": {
+			"name": "videos_authors",
+			"columns": {
+				"video_id": {
+					"name": "video_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"videos_authors_video_id_videos_id_fk": {
+					"name": "videos_authors_video_id_videos_id_fk",
+					"tableFrom": "videos_authors",
+					"tableTo": "videos",
+					"columnsFrom": ["video_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"videos_authors_author_id_authors_id_fk": {
+					"name": "videos_authors_author_id_authors_id_fk",
+					"tableFrom": "videos_authors",
+					"tableTo": "authors",
+					"columnsFrom": ["author_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"videos_authors_video_id_author_id_pk": {
+					"columns": ["video_id", "author_id"],
+					"name": "videos_authors_video_id_author_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"videos_contents": {
+			"name": "videos_contents",
+			"columns": {
+				"video_id": {
+					"name": "video_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content_id": {
+					"name": "content_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"order": {
+					"name": "order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"videos_contents_video_id_videos_id_fk": {
+					"name": "videos_contents_video_id_videos_id_fk",
+					"tableFrom": "videos_contents",
+					"tableTo": "videos",
+					"columnsFrom": ["video_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"videos_contents_content_id_contents_id_fk": {
+					"name": "videos_contents_content_id_contents_id_fk",
+					"tableFrom": "videos_contents",
+					"tableTo": "contents",
+					"columnsFrom": ["content_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"videos_contents_video_id_content_id_pk": {
+					"columns": ["video_id", "content_id"],
+					"name": "videos_contents_video_id_content_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"videos_tags": {
+			"name": "videos_tags",
+			"columns": {
+				"video_id": {
+					"name": "video_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tag_id": {
+					"name": "tag_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"videos_tags_video_id_videos_id_fk": {
+					"name": "videos_tags_video_id_videos_id_fk",
+					"tableFrom": "videos_tags",
+					"tableTo": "videos",
+					"columnsFrom": ["video_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"videos_tags_tag_id_tags_id_fk": {
+					"name": "videos_tags_tag_id_tags_id_fk",
+					"tableFrom": "videos_tags",
+					"tableTo": "tags",
+					"columnsFrom": ["tag_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"videos_tags_video_id_tag_id_pk": {
+					"columns": ["video_id", "tag_id"],
+					"name": "videos_tags_video_id_tag_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/drizzle/application/meta/_journal.json
+++ b/drizzle/application/meta/_journal.json
@@ -15,6 +15,13 @@
 			"when": 1767394689984,
 			"tag": "0001_last_gladiator",
 			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "6",
+			"when": 1767619007104,
+			"tag": "0002_cool_grandmaster",
+			"breakpoints": true
 		}
 	]
 }

--- a/features/duplicate-content/content.hash.datasource.ts
+++ b/features/duplicate-content/content.hash.datasource.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, gt } from "drizzle-orm";
 import { CONTENT_HASHS } from "../shared/database/application/schema.js";
 import type { Database } from "../shared/database/application/type.js";
 import type { ContentHash } from "./content.hash.model.js";
@@ -56,6 +56,43 @@ export class ContentHashDataSource implements ContentHashRepository {
 			.where(eq(CONTENT_HASHS.type, type));
 
 		return rows;
+	}
+
+	async *findByTypeBatched(
+		type: string,
+		batchSize = 100,
+	): AsyncIterable<ContentHash[]> {
+		let cursor: string | undefined;
+
+		while (true) {
+			const conditions = cursor
+				? and(eq(CONTENT_HASHS.type, type), gt(CONTENT_HASHS.id, cursor))
+				: eq(CONTENT_HASHS.type, type);
+
+			const rows = await this.db
+				.select({
+					id: CONTENT_HASHS.id,
+					contentId: CONTENT_HASHS.contentId,
+					type: CONTENT_HASHS.type,
+					value: CONTENT_HASHS.value,
+				})
+				.from(CONTENT_HASHS)
+				.where(conditions)
+				.orderBy(CONTENT_HASHS.id)
+				.limit(batchSize);
+
+			if (rows.length === 0) {
+				break;
+			}
+
+			yield rows;
+
+			if (rows.length < batchSize) {
+				break;
+			}
+
+			cursor = rows[rows.length - 1]?.id;
+		}
 	}
 
 	async deleteByContentId(contentId: string): Promise<void> {

--- a/features/duplicate-content/content.hash.datasource.ts
+++ b/features/duplicate-content/content.hash.datasource.ts
@@ -44,6 +44,20 @@ export class ContentHashDataSource implements ContentHashRepository {
 		return rows;
 	}
 
+	async findByType(type: string): Promise<ContentHash[]> {
+		const rows = await this.db
+			.select({
+				id: CONTENT_HASHS.id,
+				contentId: CONTENT_HASHS.contentId,
+				type: CONTENT_HASHS.type,
+				value: CONTENT_HASHS.value,
+			})
+			.from(CONTENT_HASHS)
+			.where(eq(CONTENT_HASHS.type, type));
+
+		return rows;
+	}
+
 	async deleteByContentId(contentId: string): Promise<void> {
 		await this.db
 			.delete(CONTENT_HASHS)

--- a/features/duplicate-content/content.hash.repository.ts
+++ b/features/duplicate-content/content.hash.repository.ts
@@ -3,6 +3,7 @@ import type { ContentHash } from "./content.hash.model.js";
 export interface ContentHashRepository {
 	save(contentHash: ContentHash): Promise<ContentHash>;
 	findByTypeAndValue(type: string, value: string): Promise<ContentHash[]>;
+	findByType(type: string): Promise<ContentHash[]>;
 
 	deleteByContentId(contentId: string): Promise<void>;
 }

--- a/features/duplicate-content/content.hash.repository.ts
+++ b/features/duplicate-content/content.hash.repository.ts
@@ -4,6 +4,15 @@ export interface ContentHashRepository {
 	save(contentHash: ContentHash): Promise<ContentHash>;
 	findByTypeAndValue(type: string, value: string): Promise<ContentHash[]>;
 	findByType(type: string): Promise<ContentHash[]>;
+	/**
+	 * バッチ単位でContentHashを取得するAsyncIterableを返す
+	 * @param type ハッシュタイプ
+	 * @param batchSize 1バッチあたりの取得件数（デフォルト: 100）
+	 */
+	findByTypeBatched(
+		type: string,
+		batchSize?: number,
+	): AsyncIterable<ContentHash[]>;
 
 	deleteByContentId(contentId: string): Promise<void>;
 }

--- a/features/duplicate-content/job/similarity-scan.handler.ts
+++ b/features/duplicate-content/job/similarity-scan.handler.ts
@@ -123,14 +123,16 @@ export class SimilarityScanHandler {
 		const groupIds = Array.from(existingGroups.keys());
 
 		if (groupIds.length > 1) {
-			// 複数グループが見つかった場合はマージが必要（複雑なのでログ出力のみ）
+			// 複数グループが見つかった場合はマージが必要
+			// データ不整合を防ぐため処理をスキップし、手動解決を促す
 			this.logger.warn(
-				"Multiple existing dhash groups found, manual resolution may be needed",
+				"Multiple existing dhash groups found, skipping to prevent data inconsistency. Manual resolution required.",
 				{
 					contentId,
 					groupIds,
 				},
 			);
+			return false;
 		}
 
 		const firstGroupId = groupIds[0];

--- a/features/duplicate-content/job/similarity-scan.handler.ts
+++ b/features/duplicate-content/job/similarity-scan.handler.ts
@@ -1,0 +1,187 @@
+import type { Logger } from "winston";
+import type { ContentHashRepository } from "../content.hash.repository.js";
+import type { DuplicateGroup } from "../duplicate.content.model.js";
+import type { DuplicateContentRepository } from "../duplicate.content.repository.js";
+import type { HashService } from "../hash.service.js";
+import type { ContentHashWithQueue } from "../scan-queue.model.js";
+import type { ScanQueueRepository } from "../scan-queue.repository.js";
+
+const SIMILARITY_THRESHOLD = 90;
+
+export class SimilarityScanHandler {
+	constructor(
+		private readonly logger: Logger,
+		private readonly scanQueueRepository: ScanQueueRepository,
+		private readonly contentHashRepository: ContentHashRepository,
+		private readonly duplicateContentRepository: DuplicateContentRepository,
+		private readonly hashService: HashService,
+	) {}
+
+	async execute(): Promise<{ processed: number; groupsCreated: number }> {
+		// キューからスキャン待ちのdHashを取得
+		const queueItems = await this.scanQueueRepository.findWithHash();
+		if (queueItems.length === 0) {
+			return { processed: 0, groupsCreated: 0 };
+		}
+
+		// 既存の全dHashを取得
+		const allDhashes = await this.contentHashRepository.findByType("dhash");
+
+		let groupsCreated = 0;
+
+		for (const queueItem of queueItems) {
+			const similarPairs = await this.findSimilarHashes(queueItem, allDhashes);
+
+			if (similarPairs.length > 0) {
+				const created = await this.updateOrCreateGroup(
+					queueItem.contentId,
+					similarPairs,
+				);
+				if (created) {
+					groupsCreated++;
+				}
+			}
+
+			// キューから削除
+			await this.scanQueueRepository.remove(queueItem.queueId);
+		}
+
+		this.logger.info("Similarity scan completed", {
+			processed: queueItems.length,
+			groupsCreated,
+		});
+
+		return { processed: queueItems.length, groupsCreated };
+	}
+
+	private async findSimilarHashes(
+		queueItem: ContentHashWithQueue,
+		allDhashes: { id: string; contentId: string; value: string }[],
+	): Promise<{ contentId: string; similarity: number }[]> {
+		const similarPairs: { contentId: string; similarity: number }[] = [];
+
+		for (const existingHash of allDhashes) {
+			// 自身は除外
+			if (existingHash.contentId === queueItem.contentId) {
+				continue;
+			}
+
+			try {
+				const similarity = this.hashService.compareByHammingDistance(
+					queueItem.hashValue,
+					existingHash.value,
+				);
+
+				if (similarity >= SIMILARITY_THRESHOLD) {
+					similarPairs.push({
+						contentId: existingHash.contentId,
+						similarity,
+					});
+				}
+			} catch (error) {
+				this.logger.warn("Failed to compare hashes", {
+					queueContentId: queueItem.contentId,
+					existingContentId: existingHash.contentId,
+					error,
+				});
+			}
+		}
+
+		return similarPairs;
+	}
+
+	private async updateOrCreateGroup(
+		contentId: string,
+		similarPairs: { contentId: string; similarity: number }[],
+	): Promise<boolean> {
+		// 類似コンテンツの既存グループを確認
+		const existingGroups = new Map<string, DuplicateGroup>();
+
+		for (const pair of similarPairs) {
+			const group =
+				await this.duplicateContentRepository.findByContentIdAndHashType(
+					pair.contentId,
+					"dhash",
+				);
+			if (group) {
+				existingGroups.set(group.id, group);
+			}
+		}
+
+		// 自身の既存グループも確認
+		const ownGroup =
+			await this.duplicateContentRepository.findByContentIdAndHashType(
+				contentId,
+				"dhash",
+			);
+		if (ownGroup) {
+			existingGroups.set(ownGroup.id, ownGroup);
+		}
+
+		const groupIds = Array.from(existingGroups.keys());
+
+		if (groupIds.length > 1) {
+			// 複数グループが見つかった場合はマージが必要（複雑なのでログ出力のみ）
+			this.logger.warn(
+				"Multiple existing dhash groups found, manual resolution may be needed",
+				{
+					contentId,
+					groupIds,
+				},
+			);
+		}
+
+		const firstGroupId = groupIds[0];
+		if (groupIds.length >= 1 && firstGroupId) {
+			// 既存グループに追加
+			const existingGroup = existingGroups.get(firstGroupId);
+			if (existingGroup) {
+				// 新しいコンテンツを追加
+				const alreadyExists = existingGroup.items.some(
+					(item) => item.contentId === contentId,
+				);
+				if (!alreadyExists) {
+					// 平均類似度を計算
+					const avgSimilarity = Math.round(
+						similarPairs.reduce((sum, p) => sum + p.similarity, 0) /
+							similarPairs.length,
+					);
+					existingGroup.items.push({ contentId, similarity: avgSimilarity });
+					await this.duplicateContentRepository.save(existingGroup);
+					this.logger.debug("Added content to existing dhash group", {
+						contentId,
+						groupId: existingGroup.id,
+						similarity: avgSimilarity,
+					});
+				}
+				return false;
+			}
+		}
+
+		// 新規グループ作成
+		const avgSimilarity = Math.round(
+			similarPairs.reduce((sum, p) => sum + p.similarity, 0) /
+				similarPairs.length,
+		);
+
+		const newGroup: DuplicateGroup = {
+			id: await this.duplicateContentRepository.generateId(),
+			hashType: "dhash",
+			items: [
+				...similarPairs.map((p) => ({
+					contentId: p.contentId,
+					similarity: p.similarity,
+				})),
+				{ contentId, similarity: avgSimilarity },
+			],
+		};
+
+		await this.duplicateContentRepository.save(newGroup);
+		this.logger.debug("Created new dhash duplicate group", {
+			groupId: newGroup.id,
+			contentIds: newGroup.items.map((i) => i.contentId),
+		});
+
+		return true;
+	}
+}

--- a/features/duplicate-content/job/similarity-scan.job.ts
+++ b/features/duplicate-content/job/similarity-scan.job.ts
@@ -1,0 +1,8 @@
+export type SimilarityScanJobPayload = {
+	contentIds?: string[]; // 指定がなければキュー全件
+};
+
+export type SimilarityScanJob = {
+	type: "similarity-scan";
+	payload: SimilarityScanJobPayload;
+};

--- a/features/duplicate-content/scan-queue.datasource.ts
+++ b/features/duplicate-content/scan-queue.datasource.ts
@@ -1,0 +1,75 @@
+import { count, eq } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+import {
+	CONTENT_HASHS,
+	SIMILARITY_SCAN_QUEUE,
+} from "../shared/database/application/schema.js";
+import type { Database } from "../shared/database/application/type.js";
+import type {
+	ContentHashWithQueue,
+	ScanQueueItem,
+} from "./scan-queue.model.js";
+import type { ScanQueueRepository } from "./scan-queue.repository.js";
+
+export class ScanQueueDataSource implements ScanQueueRepository {
+	constructor(private readonly db: Database) {}
+
+	async add(contentHashId: string): Promise<void> {
+		await this.db.insert(SIMILARITY_SCAN_QUEUE).values({
+			id: uuidv4(),
+			contentHashId,
+		});
+	}
+
+	async count(): Promise<number> {
+		const result = await this.db
+			.select({ count: count() })
+			.from(SIMILARITY_SCAN_QUEUE);
+		return result[0]?.count ?? 0;
+	}
+
+	async findAll(): Promise<ScanQueueItem[]> {
+		const rows = await this.db
+			.select({
+				id: SIMILARITY_SCAN_QUEUE.id,
+				contentHashId: SIMILARITY_SCAN_QUEUE.contentHashId,
+				createdAt: SIMILARITY_SCAN_QUEUE.createdAt,
+			})
+			.from(SIMILARITY_SCAN_QUEUE);
+
+		return rows;
+	}
+
+	async findWithHash(): Promise<ContentHashWithQueue[]> {
+		const rows = await this.db
+			.select({
+				queueId: SIMILARITY_SCAN_QUEUE.id,
+				contentHashId: SIMILARITY_SCAN_QUEUE.contentHashId,
+				contentId: CONTENT_HASHS.contentId,
+				hashValue: CONTENT_HASHS.value,
+			})
+			.from(SIMILARITY_SCAN_QUEUE)
+			.innerJoin(
+				CONTENT_HASHS,
+				eq(SIMILARITY_SCAN_QUEUE.contentHashId, CONTENT_HASHS.id),
+			);
+
+		return rows;
+	}
+
+	async remove(id: string): Promise<void> {
+		await this.db
+			.delete(SIMILARITY_SCAN_QUEUE)
+			.where(eq(SIMILARITY_SCAN_QUEUE.id, id));
+	}
+
+	async removeByContentHashId(contentHashId: string): Promise<void> {
+		await this.db
+			.delete(SIMILARITY_SCAN_QUEUE)
+			.where(eq(SIMILARITY_SCAN_QUEUE.contentHashId, contentHashId));
+	}
+
+	async clear(): Promise<void> {
+		await this.db.delete(SIMILARITY_SCAN_QUEUE);
+	}
+}

--- a/features/duplicate-content/scan-queue.datasource.ts
+++ b/features/duplicate-content/scan-queue.datasource.ts
@@ -15,6 +15,17 @@ export class ScanQueueDataSource implements ScanQueueRepository {
 	constructor(private readonly db: Database) {}
 
 	async add(contentHashId: string): Promise<void> {
+		// 既存のエントリがあるかチェック（重複防止）
+		const existing = await this.db
+			.select({ id: SIMILARITY_SCAN_QUEUE.id })
+			.from(SIMILARITY_SCAN_QUEUE)
+			.where(eq(SIMILARITY_SCAN_QUEUE.contentHashId, contentHashId))
+			.limit(1);
+
+		if (existing.length > 0) {
+			return;
+		}
+
 		await this.db.insert(SIMILARITY_SCAN_QUEUE).values({
 			id: uuidv4(),
 			contentHashId,

--- a/features/duplicate-content/scan-queue.model.ts
+++ b/features/duplicate-content/scan-queue.model.ts
@@ -1,0 +1,12 @@
+export type ScanQueueItem = {
+	id: string;
+	contentHashId: string;
+	createdAt: string;
+};
+
+export type ContentHashWithQueue = {
+	queueId: string;
+	contentHashId: string;
+	contentId: string;
+	hashValue: string;
+};

--- a/features/duplicate-content/scan-queue.repository.ts
+++ b/features/duplicate-content/scan-queue.repository.ts
@@ -1,0 +1,14 @@
+import type {
+	ContentHashWithQueue,
+	ScanQueueItem,
+} from "./scan-queue.model.js";
+
+export interface ScanQueueRepository {
+	add(contentHashId: string): Promise<void>;
+	count(): Promise<number>;
+	findAll(): Promise<ScanQueueItem[]>;
+	findWithHash(): Promise<ContentHashWithQueue[]>;
+	remove(id: string): Promise<void>;
+	removeByContentHashId(contentHashId: string): Promise<void>;
+	clear(): Promise<void>;
+}

--- a/features/duplicate-content/ui/templates/duplicate.list.template.tsx
+++ b/features/duplicate-content/ui/templates/duplicate.list.template.tsx
@@ -1,3 +1,4 @@
+import { PositiveButton } from "../../../shared/ui/components/button.component.js";
 import type { DuplicateGroup } from "../../duplicate.content.model.js";
 import { DuplicateGroupCard } from "../components/duplicate.group.card.component.js";
 
@@ -5,12 +6,20 @@ interface DuplicateListTemplateProps<T extends DuplicateGroup> {
 	groups: T[];
 	getThumbnailUrl: (group: T) => string | undefined;
 	onGroupClick: (groupId: string) => void;
+	queueCount?: number;
+	threshold?: number;
+	isScanning?: boolean;
+	onRunScan?: () => void;
 }
 
 export function DuplicateListTemplate<T extends DuplicateGroup>({
 	groups,
 	getThumbnailUrl,
 	onGroupClick,
+	queueCount = 0,
+	threshold = 10,
+	isScanning = false,
+	onRunScan,
 }: DuplicateListTemplateProps<T>) {
 	return (
 		<main className="container mx-auto flex flex-col justify-center px-2 pt-10">
@@ -22,6 +31,33 @@ export function DuplicateListTemplate<T extends DuplicateGroup>({
 				<p className="text-gray-600">
 					同一または類似のコンテンツグループを表示しています
 				</p>
+			</div>
+
+			{/* スキャン待ちキュー情報・スキャンボタン */}
+			<div className="mb-6 flex items-center gap-4 rounded-lg bg-gray-50 p-4">
+				<div className="flex-1">
+					<p className="font-medium text-gray-700 text-sm">
+						類似スキャン待ち: {queueCount}件 / {threshold}件で自動実行
+					</p>
+					{queueCount > 0 && (
+						<div className="mt-2 h-2 w-full max-w-xs overflow-hidden rounded-full bg-gray-200">
+							<div
+								className="h-full bg-blue-500 transition-all duration-300"
+								style={{
+									width: `${Math.min((queueCount / threshold) * 100, 100)}%`,
+								}}
+							/>
+						</div>
+					)}
+				</div>
+				{onRunScan && (
+					<PositiveButton
+						onClick={onRunScan}
+						disabled={isScanning || queueCount === 0}
+					>
+						{isScanning ? "スキャン中..." : "類似スキャン実行"}
+					</PositiveButton>
+				)}
 			</div>
 
 			{/* 検索結果情報 */}

--- a/features/duplicate-content/ui/templates/duplicate.list.template.tsx
+++ b/features/duplicate-content/ui/templates/duplicate.list.template.tsx
@@ -44,7 +44,10 @@ export function DuplicateListTemplate<T extends DuplicateGroup>({
 							<div
 								className="h-full bg-blue-500 transition-all duration-300"
 								style={{
-									width: `${Math.min((queueCount / threshold) * 100, 100)}%`,
+									width:
+										threshold > 0
+											? `${Math.min((queueCount / threshold) * 100, 100)}%`
+											: "0%",
 								}}
 							/>
 						</div>

--- a/features/shared/database/application/schema.ts
+++ b/features/shared/database/application/schema.ts
@@ -76,6 +76,15 @@ export const DUPLICATE_GROUP_ITEMS = sqliteTable(
 	(table) => [primaryKey({ columns: [table.groupId, table.contentId] })],
 );
 
+// 類似スキャン待ちキュー
+export const SIMILARITY_SCAN_QUEUE = sqliteTable("similarity_scan_queue", {
+	id: text("id").primaryKey(),
+	contentHashId: text("content_hash_id")
+		.notNull()
+		.references(() => CONTENT_HASHS.id, { onDelete: "cascade" }),
+	createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+});
+
 // 中間テーブル
 export const VIDEOS_TAGS = sqliteTable(
 	"videos_tags",

--- a/src/main/apis/duplicates/duplicate.scan.api.ts
+++ b/src/main/apis/duplicates/duplicate.scan.api.ts
@@ -1,0 +1,31 @@
+import type { Context } from "../../context.js";
+import { TOKENS } from "../../di/token.js";
+
+export async function runSimilarityScan(ctx: Context) {
+	const { container } = ctx;
+	const [logger, duplicateContentAction] = container.get(
+		TOKENS.LOGGER,
+		TOKENS.DUPLICATE_CONTENT_ACTION,
+	);
+	logger.info("Running manual similarity scan");
+
+	const result = await duplicateContentAction.runManualScan();
+
+	return {
+		success: true,
+		processed: result.processed,
+		groupsCreated: result.groupsCreated,
+	};
+}
+
+export async function getQueueCount(ctx: Context) {
+	const { container } = ctx;
+	const duplicateContentAction = container.get(TOKENS.DUPLICATE_CONTENT_ACTION);
+
+	const count = await duplicateContentAction.getQueueCount();
+
+	return {
+		count,
+		threshold: 10, // BATCH_THRESHOLD
+	};
+}

--- a/src/main/autogenerate/register.ts
+++ b/src/main/autogenerate/register.ts
@@ -19,6 +19,7 @@ import { deleteDuplicateGroup, deleteDuplicateGroupValidator } from "../apis/dup
 import { getDuplicateGroup, getDuplicateGroupValidator } from "../apis/duplicates/duplicate.detail.api.js";
 import { listDuplicateGroups } from "../apis/duplicates/duplicate.list.api.js";
 import { removeItemFromGroup, removeItemFromGroupValidator } from "../apis/duplicates/duplicate.remove-item.api.js";
+import { getQueueCount, runSimilarityScan } from "../apis/duplicates/duplicate.scan.api.js";
 import { deleteIllust, deleteIllustValidator } from "../apis/illusts/illust.delete.api.js";
 import { detailIllust, detailIllustValidator } from "../apis/illusts/illust.detail.api.js";
 import { pickupImage } from "../apis/illusts/illust.pickup.api.js";
@@ -191,6 +192,26 @@ export const autoGenerateHandlers = {
             try {
                 const validatedArgs = removeItemFromGroupValidator(args, { ...ctx, event });
                 const result = await removeItemFromGroup({ ...ctx, event }, validatedArgs);
+                return success(result);
+            } catch (e) {
+                return customErrorHandler(e, { ...ctx, event });
+            }
+        };
+    },
+    "getQueueCount": (ctx: Omit<Context, "event">) => {
+        return async (event: IpcMainInvokeEvent, _: unknown) => {
+            try {
+                const result = await getQueueCount({ ...ctx, event });
+                return success(result);
+            } catch (e) {
+                return customErrorHandler(e, { ...ctx, event });
+            }
+        };
+    },
+    "runSimilarityScan": (ctx: Omit<Context, "event">) => {
+        return async (event: IpcMainInvokeEvent, _: unknown) => {
+            try {
+                const result = await runSimilarityScan({ ...ctx, event });
                 return success(result);
             } catch (e) {
                 return customErrorHandler(e, { ...ctx, event });

--- a/src/main/di/dependencies.ts
+++ b/src/main/di/dependencies.ts
@@ -6,6 +6,8 @@ import { ContentHashDataSource } from "../../../features/duplicate-content/conte
 import { DuplicateContentAction } from "../../../features/duplicate-content/duplicate.content.action.js";
 import { DuplicateContentDataSource } from "../../../features/duplicate-content/duplicate.content.datasource.js";
 import { HashService } from "../../../features/duplicate-content/hash.service.js";
+import { SimilarityScanHandler } from "../../../features/duplicate-content/job/similarity-scan.handler.js";
+import { ScanQueueDataSource } from "../../../features/duplicate-content/scan-queue.datasource.js";
 import { IllustAction } from "../../../features/illust/illust.action.js";
 import { IllustDataSource } from "../../../features/illust/illust.datasource.js";
 import { ProjectDataSource } from "../../../features/project/project.datasource.js";
@@ -106,6 +108,10 @@ export const depend: DependencyEntry[] = [
 		provider: (c: Container) =>
 			new DuplicateContentDataSource(c.get(TOKENS.DATABASE)),
 	},
+	{
+		token: TOKENS.SCAN_QUEUE_REPOSITORY,
+		provider: (c: Container) => new ScanQueueDataSource(c.get(TOKENS.DATABASE)),
+	},
 
 	// service
 	{
@@ -139,6 +145,17 @@ export const depend: DependencyEntry[] = [
 				c.get(TOKENS.TAG_COOCCURRENCE_REPOSITORY),
 			),
 	},
+	{
+		token: TOKENS.SIMILARITY_SCAN_HANDLER,
+		provider: (c: Container) =>
+			new SimilarityScanHandler(
+				c.get(TOKENS.LOGGER),
+				c.get(TOKENS.SCAN_QUEUE_REPOSITORY),
+				c.get(TOKENS.CONTENT_HASH_REPOSITORY),
+				c.get(TOKENS.DUPLICATE_CONTENT_REPOSITORY),
+				c.get(TOKENS.HASH_SERVICE),
+			),
+	},
 
 	// action
 	{
@@ -149,6 +166,9 @@ export const depend: DependencyEntry[] = [
 				c.get(TOKENS.CALCULATOR_FACTORY),
 				c.get(TOKENS.DUPLICATE_CONTENT_REPOSITORY),
 				c.get(TOKENS.CONTENT_HASH_REPOSITORY),
+				c.get(TOKENS.SCAN_QUEUE_REPOSITORY),
+				c.get(TOKENS.JOB_QUEUE),
+				c.get(TOKENS.SIMILARITY_SCAN_HANDLER),
 			),
 	},
 	{

--- a/src/main/di/token.ts
+++ b/src/main/di/token.ts
@@ -8,6 +8,8 @@ import type { ContentHashRepository } from "../../../features/duplicate-content/
 import type { DuplicateContentAction } from "../../../features/duplicate-content/duplicate.content.action.js";
 import type { DuplicateContentRepository } from "../../../features/duplicate-content/duplicate.content.repository.js";
 import type { HashService } from "../../../features/duplicate-content/hash.service.js";
+import type { SimilarityScanHandler } from "../../../features/duplicate-content/job/similarity-scan.handler.js";
+import type { ScanQueueRepository } from "../../../features/duplicate-content/scan-queue.repository.js";
 import type { IllustAction } from "../../../features/illust/illust.action.js";
 import type { IllustRepository } from "../../../features/illust/illust.repository.js";
 import type { ProjectContext } from "../../../features/project/project.context.js";
@@ -66,6 +68,9 @@ export const TOKENS = {
 	DUPLICATE_CONTENT_REPOSITORY: new InjectionToken<DuplicateContentRepository>(
 		"DuplicateContentRepository",
 	),
+	SCAN_QUEUE_REPOSITORY: new InjectionToken<ScanQueueRepository>(
+		"ScanQueueRepository",
+	),
 
 	// service
 	HASH_SERVICE: new InjectionToken<HashService>("HashService"),
@@ -75,6 +80,9 @@ export const TOKENS = {
 	VIDEO_SERVICE: new InjectionToken<VideoService>("VideoService"),
 	TAG_SUGGESTION_SERVICE: new InjectionToken<TagSuggestionService>(
 		"TagSuggestionService",
+	),
+	SIMILARITY_SCAN_HANDLER: new InjectionToken<SimilarityScanHandler>(
+		"SimilarityScanHandler",
 	),
 
 	// action

--- a/src/preload/autogenerate/register.ts
+++ b/src/preload/autogenerate/register.ts
@@ -17,6 +17,8 @@ export default {
     getDuplicateGroup: (groupId: string) => ipcRenderer.invoke("getDuplicateGroup", { groupId }),
     listDuplicateGroups: () => ipcRenderer.invoke("listDuplicateGroups", {  }),
     removeItemFromGroup: (groupId: string, contentId: string) => ipcRenderer.invoke("removeItemFromGroup", { groupId, contentId }),
+    getQueueCount: () => ipcRenderer.invoke("getQueueCount", {  }),
+    runSimilarityScan: () => ipcRenderer.invoke("runSimilarityScan", {  }),
     deleteIllust: (illustId: string) => ipcRenderer.invoke("deleteIllust", { illustId }),
     detailIllust: (illustId: string) => ipcRenderer.invoke("detailIllust", { illustId }),
     pickupImage: () => ipcRenderer.invoke("pickupImage", {  }),

--- a/src/renderer/autogenerate/register.tsx
+++ b/src/renderer/autogenerate/register.tsx
@@ -14,6 +14,7 @@ import type { deleteDuplicateGroup } from "../../main/apis/duplicates/duplicate.
 import type { getDuplicateGroup } from "../../main/apis/duplicates/duplicate.detail.api.js";
 import type { listDuplicateGroups } from "../../main/apis/duplicates/duplicate.list.api.js";
 import type { removeItemFromGroup } from "../../main/apis/duplicates/duplicate.remove-item.api.js";
+import type { getQueueCount, runSimilarityScan } from "../../main/apis/duplicates/duplicate.scan.api.js";
 import type { deleteIllust } from "../../main/apis/illusts/illust.delete.api.js";
 import type { detailIllust } from "../../main/apis/illusts/illust.detail.api.js";
 import type { pickupImage } from "../../main/apis/illusts/illust.pickup.api.js";
@@ -58,6 +59,8 @@ declare global {
             getDuplicateGroup: (groupId: string) => Promise<Result<ReturnTypeUnwrapped<typeof getDuplicateGroup>, unknown>>;
             listDuplicateGroups: () => Promise<Result<ReturnTypeUnwrapped<typeof listDuplicateGroups>, unknown>>;
             removeItemFromGroup: (groupId: string, contentId: string) => Promise<Result<ReturnTypeUnwrapped<typeof removeItemFromGroup>, unknown>>;
+            getQueueCount: () => Promise<Result<ReturnTypeUnwrapped<typeof getQueueCount>, unknown>>;
+            runSimilarityScan: () => Promise<Result<ReturnTypeUnwrapped<typeof runSimilarityScan>, unknown>>;
             deleteIllust: (illustId: string) => Promise<Result<ReturnTypeUnwrapped<typeof deleteIllust>, unknown>>;
             detailIllust: (illustId: string) => Promise<Result<ReturnTypeUnwrapped<typeof detailIllust>, unknown>>;
             pickupImage: () => Promise<Result<ReturnTypeUnwrapped<typeof pickupImage>, unknown>>;
@@ -95,6 +98,8 @@ export interface ServiceIF {
     getDuplicateGroup: (groupId: string) => Promise<Result<ReturnTypeUnwrapped<typeof getDuplicateGroup>, unknown>>;
     listDuplicateGroups: () => Promise<Result<ReturnTypeUnwrapped<typeof listDuplicateGroups>, unknown>>;
     removeItemFromGroup: (groupId: string, contentId: string) => Promise<Result<ReturnTypeUnwrapped<typeof removeItemFromGroup>, unknown>>;
+    getQueueCount: () => Promise<Result<ReturnTypeUnwrapped<typeof getQueueCount>, unknown>>;
+    runSimilarityScan: () => Promise<Result<ReturnTypeUnwrapped<typeof runSimilarityScan>, unknown>>;
     deleteIllust: (illustId: string) => Promise<Result<ReturnTypeUnwrapped<typeof deleteIllust>, unknown>>;
     detailIllust: (illustId: string) => Promise<Result<ReturnTypeUnwrapped<typeof detailIllust>, unknown>>;
     pickupImage: () => Promise<Result<ReturnTypeUnwrapped<typeof pickupImage>, unknown>>;
@@ -173,6 +178,14 @@ export class ApiService implements ServiceIF {
 
     async removeItemFromGroup(groupId: string, contentId: string) {
         return window.api.removeItemFromGroup(groupId, contentId);
+    }
+
+    async getQueueCount() {
+        return window.api.getQueueCount();
+    }
+
+    async runSimilarityScan() {
+        return window.api.runSimilarityScan();
     }
 
     async deleteIllust(illustId: string) {

--- a/src/renderer/pages/duplicate.list.page.tsx
+++ b/src/renderer/pages/duplicate.list.page.tsx
@@ -1,6 +1,6 @@
-import { isFailure } from "electron-flow/result";
-import { useCallback } from "react";
-import { useLoaderData, useNavigate } from "react-router-dom";
+import { isFailure, isSuccess } from "electron-flow/result";
+import { useCallback, useState } from "react";
+import { useLoaderData, useNavigate, useRevalidator } from "react-router-dom";
 import type { DuplicateGroup } from "../../../features/duplicate-content/duplicate.content.model.js";
 import { DuplicateListTemplate } from "../../../features/duplicate-content/ui/templates/duplicate.list.template.js";
 import { ApiService } from "../autogenerate/register.js";
@@ -9,24 +9,45 @@ const client = new ApiService();
 
 // APIレスポンスの型（thumbnailPath付き）
 type DuplicateGroupWithThumbnail = DuplicateGroup & {
-	thumbnailPath?: string;
+	thumbnailPath?: string | undefined;
 };
 
-export async function loader() {
-	const response = await client.listDuplicateGroups();
-	if (isFailure(response)) {
+type LoaderData = {
+	groups: DuplicateGroupWithThumbnail[];
+	queueCount: number;
+	threshold: number;
+};
+
+export async function loader(): Promise<LoaderData> {
+	const [groupsResponse, queueResponse] = await Promise.all([
+		client.listDuplicateGroups(),
+		client.getQueueCount(),
+	]);
+
+	if (isFailure(groupsResponse)) {
 		throw new Error(
-			typeof response.value === "string"
-				? response.value
-				: JSON.stringify(response.value),
+			typeof groupsResponse.value === "string"
+				? groupsResponse.value
+				: JSON.stringify(groupsResponse.value),
 		);
 	}
-	return response.value;
+
+	const queueData = isSuccess(queueResponse)
+		? queueResponse.value
+		: { count: 0, threshold: 10 };
+
+	return {
+		groups: groupsResponse.value.groups,
+		queueCount: queueData.count,
+		threshold: queueData.threshold,
+	};
 }
 
 export default function DuplicateListPage() {
-	const data = useLoaderData<{ groups: DuplicateGroupWithThumbnail[] }>();
+	const data = useLoaderData<LoaderData>();
 	const navigate = useNavigate();
+	const revalidator = useRevalidator();
+	const [isScanning, setIsScanning] = useState(false);
 
 	// サムネイルURL取得（APIから取得したthumbnailPathを使用）
 	const getThumbnailUrl = (
@@ -42,11 +63,28 @@ export default function DuplicateListPage() {
 		[navigate],
 	);
 
+	const handleRunScan = useCallback(async () => {
+		setIsScanning(true);
+		try {
+			const response = await client.runSimilarityScan();
+			if (isSuccess(response)) {
+				// スキャン完了後にデータを再取得
+				revalidator.revalidate();
+			}
+		} finally {
+			setIsScanning(false);
+		}
+	}, [revalidator]);
+
 	return (
 		<DuplicateListTemplate
 			groups={data.groups}
 			getThumbnailUrl={getThumbnailUrl}
 			onGroupClick={handleGroupClick}
+			queueCount={data.queueCount}
+			threshold={data.threshold}
+			isScanning={isScanning}
+			onRunScan={handleRunScan}
 		/>
 	);
 }

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -242,4 +242,14 @@ export class FetchClient implements ServiceIF {
 	async devRecords(_tableName: string, _page: number, _limit: number) {
 		return failure(new Error("devRecords is not allowed in FetchClient"));
 	}
+
+	async runSimilarityScan() {
+		return failure(
+			new Error("runSimilarityScan is not allowed in FetchClient"),
+		);
+	}
+
+	async getQueueCount() {
+		return failure(new Error("getQueueCount is not allowed in FetchClient"));
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 類似検出用のスキャンキューを導入しました（キュー登録・集計・検索・削除が可能）。
  * バッチ処理で効率的に類似ハッシュを検出し、重複グループを自動作成／更新します。
  * 管理用の手動スキャン実行とキュー件数取得APIを追加しました（UIから実行可）。
  * リスト画面にキュー進捗表示（プログレスバー）、スキャン実行ボタン、スキャン中状態を追加しました。
  * データベースにスキャンキュー用のテーブルを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->